### PR TITLE
optimize first page load

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  background-color: var(--void-black);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
@@ -13,6 +14,7 @@ button:hover {
 }
 
 :root {
+  --void-black: #000000;
   --menu-brown: #13080e;
   --space-orange: #e8ab8c;
   --active-white: rgb(245, 245, 245);


### PR DESCRIPTION
- set background-color on whole body to black to avoid white flash on first page load